### PR TITLE
Fix bot issues

### DIFF
--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -39,7 +39,7 @@ runs:
             # Test ndarray folder update (requires parallel tests to avoid clean)
             touch ${SITE_DIR}/pyccel/stdlib/cwrapper/cwrapper.h
             python -m pytest -n auto -rXx ${FLAGS} -m c -k test_array_int32_1d_scalar epyccel/test_arrays.py 2>&1 | tee s2_outfile.out
-        fi
+         fi
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests
       id: pytest_2

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Coverage install
         uses: ./.github/actions/coverage_install
       - name: Ccuda tests with pytest
+        id: cuda_pytest
         uses: ./.github/actions/pytest_run_cuda
       - name: Collect coverage information
         continue-on-error: True
@@ -76,5 +77,5 @@ jobs:
       - name: "Post completed"
         if: always()
         run:
-          python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }} ${{ steps.valgrind.outcome }}
+          python ci_tools/complete_check_run.py ${{ steps.cuda_pytest.outcome }}
 

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -42,17 +42,17 @@ jobs:
           ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
         shell: bash
-      - name: CUDA Version
-        run: nvcc --version # cuda install check
+      - name: Install python (setup-python action doesn't work with containers)
+        uses: ./.github/actions/python_install
       - name: "Setup"
         id: token
         run: |
           pip install jwt requests
           python ci_tools/setup_check_run.py
+      - name: CUDA Version
+        run: nvcc --version # cuda install check
       - name: Install dependencies
         uses: ./.github/actions/linux_install
-      - name: Install python (setup-python action doesn't work with containers)
-        uses: ./.github/actions/python_install
       - name: Install Pyccel with tests
         run: |
             PATH=${PATH}:$HOME/.local/bin

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -48,7 +48,7 @@ jobs:
         id: token
         run: |
           pip install jwt requests
-          python ci_tools/setup_check_run.py
+          python ci_tools/setup_check_run.py cuda
       - name: CUDA Version
         run: nvcc --version # cuda install check
       - name: Install dependencies

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -419,7 +419,7 @@ class Bot:
             True if the test should be run, False otherwise.
         """
         print("Checking : ", name)
-        if key in ('linux', 'windows', 'macosx', 'anaconda_linux', 'anaconda_windows', 'coverage', 'intel'):
+        if key in ('linux', 'windows', 'macosx', 'anaconda_linux', 'anaconda_windows', 'coverage', 'intel', 'cuda'):
             has_relevant_change = lambda diff: any((f.startswith('pyccel/') or f.startswith('tests/'))  #pylint: disable=unnecessary-lambda-assignment
                                                     and f.endswith('.py') and f != 'pyccel/version.py'
                                                     for f in diff)

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -41,7 +41,8 @@ test_names = {
         'pyccel_lint': "Pyccel best practices",
         'pylint': "Python linting",
         'spelling': "Spelling verification",
-        'windows': "Unit tests on Windows"
+        'windows': "Unit tests on Windows",
+        'cuda': "Unit tests on Linux with cuda"
         }
 
 test_dependencies = {'coverage':['linux', 'cuda']}

--- a/ci_tools/devel_branch_tests.py
+++ b/ci_tools/devel_branch_tests.py
@@ -15,3 +15,4 @@ if __name__ == '__main__':
     bot.run_tests(['anaconda_linux'], '3.10', force_run = True)
     bot.run_tests(['anaconda_windows'], '3.10', force_run = True)
     bot.run_tests(['intel'], '3.9', force_run = True)
+    bot.run_tests(['cuda'], '-', force_run = True)


### PR DESCRIPTION
Fix several minor bugs with the bot. Namely:
- indenting in `pytest_run/action.yml` which prevents tests from running
- Ordering of setup in cuda workflow preventing setup action from running
- Missing argument to setup.py
- Missing description for cuda test
- Ensure cuda tests are triggered on devel branch
- Report outcome of cuda step